### PR TITLE
Import Piper.Data methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ provide deencapsulation and processing data in pipeline-like way. Example:
 
 ```elixir
 defmodule FetchFromRepoPipe do
- import Piper.Data
- alias MyApp.Repo
+  import Piper.Data
+  alias MyApp.Repo
 
   def init(opts), do: opts
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ provide deencapsulation and processing data in pipeline-like way. Example:
 
 ```elixir
 defmodule FetchFromRepoPipe do
-  alias MyApp.Repo
+ import Piper.Data
+ alias MyApp.Repo
 
   def init(opts), do: opts
 


### PR DESCRIPTION
Currently `assign/3` is outside the scope in the docs